### PR TITLE
Fix overflow in code checking for white line

### DIFF
--- a/python/src/pdf417decoder/Decoder.py
+++ b/python/src/pdf417decoder/Decoder.py
@@ -1167,7 +1167,7 @@ class PDF417Decoder:
         black_white = cv2.threshold(gray, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)[1]
         
         # padding with single white line at the leftmost of the image
-        if (sum(black_white[:, 0]) / 255) / black_white.shape[0] < 1:
+        if (not (black_white[:, 0] == 255).all()):
             black_white = np.concatenate([np.full((black_white.shape[0],1), fill_value=255, dtype=black_white.dtype), black_white], axis=1)
 
         self.image_height, self.image_width = black_white.shape[:2]


### PR DESCRIPTION
Recently added code tries to check for whitespace at the start of the image using code that always triggers an overflow warning. Use a more pythonic and direct way to do this check.